### PR TITLE
Uses the correct provider to get the peer account id

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,29 @@
-provider aws {
+provider "aws" {
   alias = "peer"
 }
 
-data aws_caller_identity peer {}
+data "aws_caller_identity" "peer" {
+  provider = aws.peer
+}
 
-data aws_vpc this {
+data "aws_vpc" "this" {
   id = var.vpc_id
 }
 
-data aws_vpc peer {
+data "aws_vpc" "peer" {
   provider = aws.peer
 
   id = var.peer_vpc_id
 }
 
-resource aws_vpc_peering_connection this {
+resource "aws_vpc_peering_connection" "this" {
   peer_owner_id = data.aws_caller_identity.peer.account_id
   peer_vpc_id   = var.peer_vpc_id
   vpc_id        = var.vpc_id
   tags          = var.tags
 }
 
-resource aws_vpc_peering_connection_accepter this {
+resource "aws_vpc_peering_connection_accepter" "this" {
   provider = aws.peer
 
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
@@ -29,7 +31,7 @@ resource aws_vpc_peering_connection_accepter this {
   tags                      = var.peer_tags
 }
 
-resource aws_route public {
+resource "aws_route" "public" {
   count = length(var.public_route_tables)
 
   route_table_id            = var.public_route_tables[count.index]
@@ -37,7 +39,7 @@ resource aws_route public {
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
 }
 
-resource aws_route private {
+resource "aws_route" "private" {
   count = length(var.private_route_tables)
 
   route_table_id            = var.private_route_tables[count.index]
@@ -45,7 +47,7 @@ resource aws_route private {
   vpc_peering_connection_id = aws_vpc_peering_connection.this.id
 }
 
-resource aws_route peer {
+resource "aws_route" "peer" {
   count = length(var.peer_route_tables)
 
   provider = aws.peer


### PR DESCRIPTION
Missed this provider reference in the earlier update. Kinda critical... :p Without this, the wrong provider is used to lookup the peer account id, which means the peering connection is totally wrong.

Results of `make test`:
```
PASS
ok      tardigarde-ci/tests     97.510s
[terratest/test]: Completed successfully!
```